### PR TITLE
refactor(middleware): use host from cookies instead of .env

### DIFF
--- a/apps/public_web/src/middleware.ts
+++ b/apps/public_web/src/middleware.ts
@@ -66,6 +66,8 @@ function getLocale(request: NextRequest) {
 }
 
 export const middleware = auth(async (request: NextAuthRequest) => {
+  const hostURL = "http://" + request.headers.get("host") || "";
+  
   function isUserAuthorized(request: NextAuthRequest) {
     return !!request.auth;
   }
@@ -74,12 +76,12 @@ export const middleware = auth(async (request: NextAuthRequest) => {
   }
   function redirectToLogin(locale: string) {
     return NextResponse.redirect(
-      new URL(`/${locale}/login`, process.env.PROJECT_BASE_URL)
+      new URL(`/${locale}/login`, hostURL)
     );
   }
   function redirectToProfile(locale: string) {
     return NextResponse.redirect(
-      new URL(`/${locale}/profile`, process.env.PROJECT_BASE_URL)
+      new URL(`/${locale}/profile`, hostURL)
     );
   }
 
@@ -100,7 +102,7 @@ export const middleware = auth(async (request: NextAuthRequest) => {
     return NextResponse.redirect(
       new URL(
         `/${locale}${request.nextUrl.pathname}`,
-        process.env.PROJECT_BASE_URL
+        hostURL
       )
     );
   }
@@ -114,7 +116,7 @@ export const middleware = auth(async (request: NextAuthRequest) => {
     return NextResponse.redirect(
       new URL(
         `/${locale}${request.nextUrl.pathname}`,
-        process.env.PROJECT_BASE_URL
+        hostURL
       )
     );
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -66,6 +66,8 @@ function getLocale(request: NextRequest) {
 }
 
 export const middleware = auth(async (request: NextAuthRequest) => {
+  const hostURL = "http://" + request.headers.get("host") || "";
+  
   function isUserAuthorized(request: NextAuthRequest) {
     return !!request.auth;
   }
@@ -74,12 +76,12 @@ export const middleware = auth(async (request: NextAuthRequest) => {
   }
   function redirectToLogin(locale: string) {
     return NextResponse.redirect(
-      new URL(`/${locale}/login`, process.env.PROJECT_BASE_URL)
+      new URL(`/${locale}/login`, hostURL)
     );
   }
   function redirectToProfile(locale: string) {
     return NextResponse.redirect(
-      new URL(`/${locale}/profile`, process.env.PROJECT_BASE_URL)
+      new URL(`/${locale}/profile`, hostURL)
     );
   }
 
@@ -100,7 +102,7 @@ export const middleware = auth(async (request: NextAuthRequest) => {
     return NextResponse.redirect(
       new URL(
         `/${locale}${request.nextUrl.pathname}`,
-        process.env.PROJECT_BASE_URL
+        hostURL
       )
     );
   }
@@ -114,7 +116,7 @@ export const middleware = auth(async (request: NextAuthRequest) => {
     return NextResponse.redirect(
       new URL(
         `/${locale}${request.nextUrl.pathname}`,
-        process.env.PROJECT_BASE_URL
+        hostURL
       )
     );
   }


### PR DESCRIPTION
Using .env file requires extra details added for all developers, using the host from the request URL save efforts. 

Here is the issue that happens when some of the developers does not have the .env variable. 
![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-core-project/assets/18273833/1963b414-4056-4e06-bf8f-4af0695766fb)
