### PR TITLE
feat: add authentication to e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .turbo
+apps/web/tests/apps/web/playwright/.auth/user.json

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+playwright/.auth

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:headed": "playwright test --headed"
   },
   "dependencies": {
     "@auth/core": "^0.30.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,10 +1,21 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
+let directory = __dirname;
+if (!directory.endsWith(`apps\\web`)) {
+  directory = directory + '\\apps\\web\\';
+}
+const authFile = directory + '\\playwright\\.auth\\user.json';
+
 require('dotenv').config();
+dotenv.config({
+  path: directory + '\\.env',
+});
+
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -37,7 +48,7 @@ export default defineConfig({
       name: 'chromium',
       use: { 
         ...devices['Desktop Chrome'],
-        storageState: 'playwright/.auth/user.json',
+        storageState: authFile,
        },
       dependencies: ['setup'],
     },
@@ -46,7 +57,7 @@ export default defineConfig({
       name: 'firefox',
       use: { 
         ...devices['Desktop Firefox'],
-        storageState: 'playwright/.auth/user.json',
+        storageState: authFile,
        },
       dependencies: ['setup'],
     },
@@ -55,7 +66,7 @@ export default defineConfig({
       name: 'webkit',
       use: { 
         ...devices['Desktop Safari'], 
-        storageState: 'playwright/.auth/user.json',
+        storageState: authFile,
        },
       dependencies: ['setup'],
     },

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -32,19 +32,32 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { 
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+       },
+      dependencies: ['setup'],
     },
 
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: { 
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+       },
+      dependencies: ['setup'],
     },
 
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: { 
+        ...devices['Desktop Safari'], 
+        storageState: 'playwright/.auth/user.json',
+       },
+      dependencies: ['setup'],
     },
 
     /* Test against mobile viewports. */

--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -1,6 +1,10 @@
 import { test as setup, expect } from '@playwright/test';
 
-const authFile = 'playwright/.auth/user.json';
+let directory = __dirname;
+if (!directory.endsWith('apps/web')) {
+  directory = directory + '/apps/web/';
+}
+const authFile = directory + '/playwright/.auth/user.json';
 
 setup('Authenticate/Login', async ({ page }) => {
     await page.goto("/");

--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -1,0 +1,20 @@
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('Authenticate/Login', async ({ page }) => {
+    await page.goto("/");
+    await page.url();
+    await page.getByPlaceholder("name@example.com").click();
+    await page
+      .getByPlaceholder("name@example.com")
+      .fill(process.env.TEST_USERNAME as string);
+    await page.getByPlaceholder("name@example.com").press("Tab");
+    await page
+      .getByPlaceholder("Password")
+      .fill(process.env.TEST_PASSWORD as string);
+    await page.getByRole("button", { name: "Login" }).click();
+    await page.url();
+    await page.getByRole("heading", { name: "admin", exact: true }).click();
+    await page.context().storageState({ path: authFile });
+});

--- a/apps/web/tests/example.spec.ts
+++ b/apps/web/tests/example.spec.ts
@@ -11,19 +11,12 @@ test.describe("Login page main functionalities", () => {
     await expect(page).toHaveTitle(/Unirefund/);
   });
 
-  test("get started link", async ({ page }) => {
+  test("Visbiility of profile and langauge buttons", async ({ page }) => {
     await page.goto("/");
     await page.url();
-    await page.getByPlaceholder("name@example.com").click();
-    await page
-      .getByPlaceholder("name@example.com")
-      .fill(process.env.TEST_USERNAME as string);
-    await page.getByPlaceholder("name@example.com").press("Tab");
-    await page
-      .getByPlaceholder("Password")
-      .fill(process.env.TEST_PASSWORD as string);
-    await page.getByRole("button", { name: "Login" }).click();
-    await page.url();
     await page.getByRole("heading", { name: "admin", exact: true }).click();
+    await expect(page.locator('body')).toContainText('admin');await expect(page.getByRole('button', { name: 'English' })).toBeVisible();
+    await expect(page.locator('h6')).toContainText('admin@abp.io');
+    await expect(page.getByRole('button', { name: 'English' })).toBeVisible();
   });
 });


### PR DESCRIPTION
This PR adds the login setup to the app, so that the tests starts when a user is logged in. 

Closes https://github.com/ayasofyazilim-clomerce/ayasofyazilim-core-project/issues/264